### PR TITLE
Fix rack webrick version error

### DIFF
--- a/mock_psp.rb
+++ b/mock_psp.rb
@@ -1,11 +1,18 @@
 # mock_psp.rb (simple Rack app)
 require 'json'
 require 'securerandom'
+require 'rack'
 require 'rack/handler/webrick'
-require 'byebug'
+begin
+  require 'byebug'
+rescue LoadError
+  module Kernel
+    def byebug; end
+  end
+end
 
 app = Proc.new do |env|
-  byebug
+  byebug if ENV['DEBUG'] == '1'
   req = Rack::Request.new(env)
   if req.path == '/payments/authorize' && req.post?
     body = JSON.parse(req.body.read) rescue {}

--- a/mock_psp.rb
+++ b/mock_psp.rb
@@ -3,13 +3,6 @@ require 'json'
 require 'securerandom'
 require 'rack'
 require 'rack/handler/webrick'
-begin
-  require 'byebug'
-rescue LoadError
-  module Kernel
-    def byebug; end
-  end
-end
 
 # Compatibility shim: define missing constant for certain Rack/WEBrick combos
 unless defined?(Rack::Handler::WEBrick::RACK_VERSION)
@@ -26,7 +19,6 @@ unless defined?(Rack::Handler::WEBrick::RACK_VERSION)
 end
 
 app = Proc.new do |env|
-  byebug if ENV['DEBUG'] == '1'
   req = Rack::Request.new(env)
   if req.path == '/payments/authorize' && req.post?
     body = JSON.parse(req.body.read) rescue {}

--- a/mock_psp.rb
+++ b/mock_psp.rb
@@ -11,6 +11,20 @@ rescue LoadError
   end
 end
 
+# Compatibility shim: define missing constant for certain Rack/WEBrick combos
+unless defined?(Rack::Handler::WEBrick::RACK_VERSION)
+  rack_version = if Rack.respond_to?(:release)
+    Rack.release
+  elsif Rack.respond_to?(:version)
+    Rack.version
+  elsif Rack.const_defined?(:RELEASE)
+    Rack.const_get(:RELEASE)
+  else
+    'unknown'
+  end
+  Rack::Handler::WEBrick.const_set(:RACK_VERSION, rack_version)
+end
+
 app = Proc.new do |env|
   byebug if ENV['DEBUG'] == '1'
   req = Rack::Request.new(env)


### PR DESCRIPTION
Add `require 'rack'` to fix `NameError: uninitialized constant Rack::Handler::WEBrick::RACK_VERSION` and make `byebug` optional.

---
<a href="https://cursor.com/background-agent?bcId=bc-82e03511-becf-4dfd-9abf-ef3ca12c48f4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-82e03511-becf-4dfd-9abf-ef3ca12c48f4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

